### PR TITLE
feat: allow executor plugin to work with older webonyx graphql versions

### DIFF
--- a/Executor/ReferenceExecutor.php
+++ b/Executor/ReferenceExecutor.php
@@ -11,6 +11,7 @@ use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\Utils;
 use Magento\Framework\App\ObjectManager;
+use ReflectionMethod;
 use SplObjectStorage;
 
 class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
@@ -54,7 +55,13 @@ class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
             return self::$executorInstance;
         }
 
-        $exeContext = static::buildExecutionContext(
+        $reflectionMethod = new ReflectionMethod(\GraphQL\Executor\ReferenceExecutor::class, 'buildExecutionContext');
+        if ($reflectionMethod->isPrivate()) {
+            $reflectionMethod->setAccessible(true);
+        }
+
+        $exeContext = $reflectionMethod->invoke(
+            null,
             $schema,
             $documentNode,
             $rootValue,

--- a/Executor/ReferenceExecutor.php
+++ b/Executor/ReferenceExecutor.php
@@ -17,27 +17,26 @@ use SplObjectStorage;
 
 class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
 {
-    /** @var ReferenceExecutor|null */
     private static ?self $executorInstance = null;
-
-    private function setPrivateProperty(string $property, $value, bool $static = false): void
-    {
-        try {
-            $reflectionProperty = new ReflectionProperty(\GraphQL\Executor\ReferenceExecutor::class, $property);
-            $reflectionProperty->setAccessible(true);
-            $reflectionProperty->setValue($static ? null : $this, $value);
-        } catch (\ReflectionException $e) {}
-    }
 
     protected function __construct(ExecutionContext $context)
     {
         if (is_callable('parent::__construct')) {
             parent::__construct($context);
         } else {
-            $this->setPrivateProperty('UNDEFINED', Utils::undefined(), true);
-            $this->setPrivateProperty('exeContext', $context);
-            $this->setPrivateProperty('subFieldCache', new SplObjectStorage());
+            $this->setExecutorPrivateProp('UNDEFINED', Utils::undefined(), true);
+            $this->setExecutorPrivateProp('exeContext', $context);
+            $this->setExecutorPrivateProp('subFieldCache', new SplObjectStorage());
         }
+    }
+
+    private function setExecutorPrivateProp(string $property, $value, bool $static = false): void
+    {
+        try {
+            $reflectionProperty = new ReflectionProperty(\GraphQL\Executor\ReferenceExecutor::class, $property);
+            $reflectionProperty->setAccessible(true);
+            $reflectionProperty->setValue($static ? null : $this, $value);
+        } catch (\ReflectionException $e) {}
     }
 
     public static function create(
@@ -72,7 +71,8 @@ class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
         );
 
         if (is_array($exeContext)) {
-            return new class($promiseAdapter->createFulfilled(new ExecutionResult(null, $exeContext))) implements ExecutorImplementation
+            $promise = $promiseAdapter->createFulfilled(new ExecutionResult(null, $exeContext));
+            return new class($promise) implements ExecutorImplementation
             {
                 private Promise $result;
 

--- a/Executor/ReferenceExecutor.php
+++ b/Executor/ReferenceExecutor.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Graycore\GraphQlIntrospectionCache\Executor;
+
+use GraphQL\Executor\ExecutionContext;
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\Executor\ExecutorImplementation;
+use GraphQL\Executor\Promise\Promise;
+use GraphQL\Executor\Promise\PromiseAdapter;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Type\Schema;
+use GraphQL\Utils\Utils;
+use Magento\Framework\App\ObjectManager;
+use SplObjectStorage;
+
+class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
+{
+    /** @var object */
+    protected static $UNDEFINED;
+
+    /** @var ExecutionContext */
+    protected $exeContext;
+
+    /** @var SplObjectStorage */
+    protected $subFieldCache;
+
+    /** @var ReferenceExecutor|null */
+    private static ?self $executorInstance = null;
+
+    protected function __construct(ExecutionContext $context)
+    {
+        if (is_callable('parent::__construct')) {
+            parent::__construct($context);
+        } else {
+            if (!static::$UNDEFINED) {
+                static::$UNDEFINED = Utils::undefined();
+            }
+            $this->exeContext = $context;
+            $this->subFieldCache = new SplObjectStorage();
+        }
+    }
+
+    public static function create(
+        PromiseAdapter $promiseAdapter,
+        Schema $schema,
+        DocumentNode $documentNode,
+        $rootValue,
+        $contextValue,
+        $variableValues,
+        ?string $operationName,
+        callable $fieldResolver
+    ) : ExecutorImplementation {
+        if (self::$executorInstance !== null) {
+            return self::$executorInstance;
+        }
+
+        $exeContext = static::buildExecutionContext(
+            $schema,
+            $documentNode,
+            $rootValue,
+            $contextValue,
+            $variableValues,
+            $operationName,
+            $fieldResolver,
+            $promiseAdapter
+        );
+
+        if (is_array($exeContext)) {
+            return new class($promiseAdapter->createFulfilled(new ExecutionResult(null, $exeContext))) implements ExecutorImplementation
+            {
+                private Promise $result;
+
+                public function __construct(Promise $result)
+                {
+                    $this->result = $result;
+                }
+
+                public function doExecute() : Promise
+                {
+                    return $this->result;
+                }
+            };
+        }
+
+        return self::$executorInstance = ObjectManager::getInstance()->create(
+            ReferenceExecutor::class,
+            ['context' => $exeContext]
+        );
+    }
+}

--- a/Executor/ReferenceExecutor.php
+++ b/Executor/ReferenceExecutor.php
@@ -12,32 +12,31 @@ use GraphQL\Type\Schema;
 use GraphQL\Utils\Utils;
 use Magento\Framework\App\ObjectManager;
 use ReflectionMethod;
+use ReflectionProperty;
 use SplObjectStorage;
 
 class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
 {
-    /** @var object */
-    protected static $UNDEFINED;
-
-    /** @var ExecutionContext */
-    protected $exeContext;
-
-    /** @var SplObjectStorage */
-    protected $subFieldCache;
-
     /** @var ReferenceExecutor|null */
     private static ?self $executorInstance = null;
+
+    private function setPrivateProperty(string $property, $value, bool $static = false): void
+    {
+        try {
+            $reflectionProperty = new ReflectionProperty(\GraphQL\Executor\ReferenceExecutor::class, $property);
+            $reflectionProperty->setAccessible(true);
+            $reflectionProperty->setValue($static ? null : $this, $value);
+        } catch (\ReflectionException $e) {}
+    }
 
     protected function __construct(ExecutionContext $context)
     {
         if (is_callable('parent::__construct')) {
             parent::__construct($context);
         } else {
-            if (!static::$UNDEFINED) {
-                static::$UNDEFINED = Utils::undefined();
-            }
-            $this->exeContext = $context;
-            $this->subFieldCache = new SplObjectStorage();
+            $this->setPrivateProperty('UNDEFINED', Utils::undefined(), true);
+            $this->setPrivateProperty('exeContext', $context);
+            $this->setPrivateProperty('subFieldCache', new SplObjectStorage());
         }
     }
 

--- a/Plugin/ExecutorPlugin.php
+++ b/Plugin/ExecutorPlugin.php
@@ -2,21 +2,12 @@
 
 namespace Graycore\GraphQlIntrospectionCache\Plugin;
 
-use Closure;
 use GraphQL\Executor\Executor;
-use GraphQL\Executor\ReferenceExecutor;
+use Graycore\GraphQlIntrospectionCache\Executor\ReferenceExecutor;
 use Magento\Framework\GraphQl\Query\QueryProcessor;
-use Magento\Framework\ObjectManagerInterface;
 
 class ExecutorPlugin
 {
-    private ObjectManagerInterface $objectManager;
-
-    public function __construct(ObjectManagerInterface $objectManager)
-    {
-        $this->objectManager = $objectManager;
-    }
-
     /**
      * Before processing a GraphQL query, replace the factory with a wrapper that uses the object manager.
      * This allows us to create plugins on the ReferenceExecutor.
@@ -25,36 +16,7 @@ class ExecutorPlugin
         QueryProcessor $subject,
         ...$args
     ): array {
-        Executor::setImplementationFactory(
-            fn(
-                $promiseAdapter,
-                $schema,
-                $documentNode,
-                $rootValue,
-                $contextValue,
-                $variableValues,
-                $operationName,
-                $fieldResolver
-            ) => $this->objectManager->create(
-                ReferenceExecutor::class,
-                [
-                    'context' => Closure::bind(
-                        fn() => ReferenceExecutor::buildExecutionContext(
-                            $schema,
-                            $documentNode,
-                            $rootValue,
-                            $contextValue,
-                            $variableValues,
-                            $operationName,
-                            $fieldResolver,
-                            $promiseAdapter
-                        ),
-                        null,
-                        ReferenceExecutor::class
-                    )()
-                ]
-            )
-        );
+        Executor::setImplementationFactory([ReferenceExecutor::class, 'create']);
         return $args;
     }
 }

--- a/Test/Integration/CachedQueryTest.php
+++ b/Test/Integration/CachedQueryTest.php
@@ -9,6 +9,9 @@ use Magento\TestFramework\Request;
 use PHPUnit\Framework\TestCase;
 use Magento\TestFramework\ObjectManager;
 
+/**
+ * @magentoAppArea graphql
+ */
 class CachedQueryTest extends TestCase
 {
     private $om;


### PR DESCRIPTION
Previous versions of the webonyx GraphQL implementation used private properties and methods. Unfortunately we have to support that version because Magento 2.4.2 uses it.

See here for more info:
https://github.com/webonyx/graphql-php/pull/801

This PR makes sure we handle both situations, falling back to reflection in case of private class internals.