### PR TITLE
fix: ensure reference executor always returns a new object

### DIFF
--- a/Executor/ReferenceExecutor.php
+++ b/Executor/ReferenceExecutor.php
@@ -17,8 +17,6 @@ use SplObjectStorage;
 
 class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
 {
-    private static ?self $executorInstance = null;
-
     protected function __construct(ExecutionContext $context)
     {
         if (is_callable('parent::__construct')) {
@@ -49,10 +47,6 @@ class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
         ?string $operationName,
         callable $fieldResolver
     ) : ExecutorImplementation {
-        if (self::$executorInstance !== null) {
-            return self::$executorInstance;
-        }
-
         $reflectionMethod = new ReflectionMethod(\GraphQL\Executor\ReferenceExecutor::class, 'buildExecutionContext');
         if ($reflectionMethod->isPrivate()) {
             $reflectionMethod->setAccessible(true);
@@ -88,7 +82,7 @@ class ReferenceExecutor extends \GraphQL\Executor\ReferenceExecutor
             };
         }
 
-        return self::$executorInstance = ObjectManager::getInstance()->create(
+        return ObjectManager::getInstance()->create(
             ReferenceExecutor::class,
             ['context' => $exeContext]
         );

--- a/Test/Integration/UniqueExecutorTest.php
+++ b/Test/Integration/UniqueExecutorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Graycore\GraphQlIntrospectionCache\Test\Integration;
+
+use GraphQL\Executor\Promise\Adapter\SyncPromiseAdapter;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Type\Schema;
+use Graycore\GraphQlIntrospectionCache\Executor\ReferenceExecutor;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+class UniqueExecutorTest extends TestCase
+{
+    public function testThatCreatedExecutorsAreUnique()
+    {
+        $om = ObjectManager::getInstance();
+
+        $promiseAdapter = $om->create(SyncPromiseAdapter::class);
+        $schema = $om->create(Schema::class, ['config' => []]);
+        $documentNode = $om->create(DocumentNode::class, ['vars' => []]);
+        $documentNode->definitions = [];
+
+        $first = ReferenceExecutor::create(
+            $promiseAdapter,
+            $schema,
+            $documentNode,
+            null,
+            null,
+            [],
+            null,
+            function() {}
+        );
+
+        $second = ReferenceExecutor::create(
+            $promiseAdapter,
+            $schema,
+            $documentNode,
+            null,
+            null,
+            [],
+            null,
+            function() {}
+        );
+
+        $this->assertNotEquals(spl_object_id($first), spl_object_id($second));
+    }
+}


### PR DESCRIPTION
Even though a typical GraphQl request only instantiates a GraphQl executor once, we shouldn't be fancy and return a singleton.

This unfortunately breaks core GraphQl integration tests. Just use a fresh object every time.